### PR TITLE
Modifies dojot device's internal representation

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -155,7 +155,7 @@ class Agent {
         ch.assertExchange(config.RABBITMQ_INBOUND_EXCHANGE, 'topic', {durable: true});
         ch.assertQueue(config.RABBITMQ_INBOUND_QUEUE,
                        {
-                         autoDelete: false, 
+                         autoDelete: false,
                          durable: true,
                          arguments: {
                            "x-message-ttl": 20000,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -39,7 +39,7 @@ class CacheHandler {
       delete this.dojot_to_device_amqp_routing_key[dojot_tenant + ':' + dojot_device_id];
       delete this.device_amqp_routing_key_to_dojot[device_amqp_routing_key];
 
-      console.log("Removing correlation dojot [%s] <-> [%s] amqp routing key", 
+      console.log("Removing correlation dojot [%s] <-> [%s] amqp routing key",
                   dojot_tenant + ':' + dojot_device_id, device_amqp_routing_key);
     }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,11 @@
+
+interface Dojot_device {
+  tenant: string;
+  device_id: string;
+}
+
 class CacheHandler {
+
     // Map correlating dojot's device ID and AMQP device routing key
     dojot_to_device_amqp_routing_key: {
       [id: string]: string
@@ -6,7 +13,7 @@ class CacheHandler {
 
     // Map correlating AMQP device routing key and dojot's device ID
     device_amqp_routing_key_to_dojot: {
-      [id: string]: string
+      [id: string]: Dojot_device
     }
 
     constructor() {
@@ -14,26 +21,35 @@ class CacheHandler {
       this.device_amqp_routing_key_to_dojot = {};
     }
 
-    correlate_dojot_and_device_amqp_routing_key(dojot_device_id: string, device_amqp_routing_key: string) {
-      this.dojot_to_device_amqp_routing_key[dojot_device_id] = device_amqp_routing_key;
-      this.device_amqp_routing_key_to_dojot[device_amqp_routing_key] = dojot_device_id;
+    correlate_dojot_and_device_amqp_routing_key(dojot_tenant: string,
+                                                dojot_device_id: string,
+                                                device_amqp_routing_key: string) {
+      let device: Dojot_device = { tenant: dojot_tenant, device_id: dojot_device_id };
 
-      console.log("Adding correlation dojot [%s] <-> [%s] amqp routing key", dojot_device_id, device_amqp_routing_key);
+      this.dojot_to_device_amqp_routing_key[dojot_tenant + ':' + dojot_device_id] = device_amqp_routing_key;
+      this.device_amqp_routing_key_to_dojot[device_amqp_routing_key] = device;
+
+      console.log("Adding correlation dojot [%s] <-> [%s] amqp routing key",
+                  dojot_tenant + ':' + dojot_device_id, device_amqp_routing_key);
     }
 
-    remove_correlation_dojot_and_device_amqp_routing_key(dojot_device_id: string, device_amqp_routing_key: string) {
-      delete this.dojot_to_device_amqp_routing_key[dojot_device_id];
+    remove_correlation_dojot_and_device_amqp_routing_key(dojot_tenant: string,
+                                                         dojot_device_id: string,
+                                                         device_amqp_routing_key: string) {
+      delete this.dojot_to_device_amqp_routing_key[dojot_tenant + ':' + dojot_device_id];
       delete this.device_amqp_routing_key_to_dojot[device_amqp_routing_key];
 
-      console.log("Removing correlation dojot [%s] <-> [%s] amqp routing key", dojot_device_id, device_amqp_routing_key);
+      console.log("Removing correlation dojot [%s] <-> [%s] amqp routing key", 
+                  dojot_tenant + ':' + dojot_device_id, device_amqp_routing_key);
     }
 
-    get_dojot_device_id(device_amqp_routing_key: string): string {
+    get_dojot_device_id(device_amqp_routing_key: string): Dojot_device {
       return this.device_amqp_routing_key_to_dojot[device_amqp_routing_key];
     }
 
-    get_device_amqp_routing_key(dojot_device_id: string) : string {
-        return this.dojot_to_device_amqp_routing_key[dojot_device_id];
+    get_device_amqp_routing_key(dojot_tenant: string,
+                                dojot_device_id: string) : string {
+        return this.dojot_to_device_amqp_routing_key[dojot_tenant + ':' + dojot_device_id];
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import fs = require("fs");
 import util = require("util");
-import {Agent} from "./agent";
+import {getAgent, Agent} from "./agent";
 
 function main() {
   if (process.argv.length != 2) {
@@ -8,7 +8,7 @@ function main() {
     return;
   }
 
-  let agent = new Agent();
+  let agent : Agent = getAgent();
   agent.start();
 }
 


### PR DESCRIPTION
- Adds tenant in the dojot device's internal representation
- Modifies how to interpret the data coming from device, now there are two modes: json and binary.
	- json mode: send as is to the upper layer
	- binary mode: convert the binary into a string base64 and add the content to a simple json with the attribute 'payload'